### PR TITLE
feat: RequestURI 확인 AOP 적용 및 환경에 따른 @EnableWebSecurity 실행 여부 분리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,7 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
+	implementation 'org.springframework.boot:spring-boot-starter-aop'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/com/se/sos/config/EnableWebSecurityConfig.java
+++ b/src/main/java/com/se/sos/config/EnableWebSecurityConfig.java
@@ -1,0 +1,11 @@
+package com.se.sos.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+
+@Configuration
+@EnableWebSecurity
+@Profile("dev")
+public class EnableWebSecurityConfig {
+}

--- a/src/main/java/com/se/sos/config/WebSecurityConfig.java
+++ b/src/main/java/com/se/sos/config/WebSecurityConfig.java
@@ -31,7 +31,6 @@ import org.springframework.web.cors.CorsConfigurationSource;
 import static com.se.sos.config.EndpointProperties.*;
 
 @Configuration
-@EnableWebSecurity(debug=true)
 @RequiredArgsConstructor
 public class WebSecurityConfig {
 

--- a/src/main/java/com/se/sos/global/util/logging/RequestLoggingAspect.java
+++ b/src/main/java/com/se/sos/global/util/logging/RequestLoggingAspect.java
@@ -1,0 +1,29 @@
+package com.se.sos.global.util.logging;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+
+@Aspect
+@Component
+@Slf4j
+@RequiredArgsConstructor
+@Profile("prod")
+public class RequestLoggingAspect {
+    private final HttpServletRequest request;
+
+    @Before("execution(* com.se.sos..*Controller.*(..))")
+    public void logBefore(){
+
+        String requestURI = request.getQueryString() != null ? request.getRequestURI()+ URLDecoder.decode(request.getQueryString(), StandardCharsets.UTF_8) : request.getRequestURI();
+
+        log.info("Request Method: {}, Request URI: {}", request.getMethod(), requestURI );
+    }
+}


### PR DESCRIPTION
## 작업 동기 및 이슈
- 서버 상에서 `@EnableWebSecurity` 설정으로 인해 swagger 요청이 로그에 기록되면서 로그를 확인하기 어렵다는 문제 발생

## 추가 및 변경사항
- 프로필(`prod`, `dev`)에 따른 `@EnableWebSecurity` 적용 - `EnableWebSecurityConfig` 클래스
- AOP 도입을 통하여 모든 콘트롤러 메서드가 실행되기 전, `HttpServletRequest`에 대하여 요청 메서드 및 URI 로깅